### PR TITLE
Create page for VIS Satellite

### DIFF
--- a/_posts/2021-08-19-vis-satellite.md
+++ b/_posts/2021-08-19-vis-satellite.md
@@ -14,4 +14,4 @@ We organize the event following CMU's COVID regulations. We expect everyone to b
 
 If you want to attend or sponsor the VIS Satellite, we will provide contact information here shortly.
 
-The organizers of the event are Adam Perer, Yu-Ru Lin, and Dominik Moritz.
+The organizers of the event are Adam Perer (CMU), Yu-Ru Lin (University of Pittsburgh), and Dominik Moritz (CMU).

--- a/_posts/2021-08-19-vis-satellite.md
+++ b/_posts/2021-08-19-vis-satellite.md
@@ -1,17 +1,27 @@
 ---
 layout: post
 title: "VIS 2021 Satellite in Pittsburgh"
+excerpt_separator: <!--more-->
 date: 2021-08-19 12:00:00 -0400
 ---
 
 We are hosting an [IEEE VIS 2021 Satellite Event](http://ieeevis.org/year/2021/info/satellite) at Carnegie Mellon University. VIS is the premier visualization conference. It usually happens every year in a different city around the world, but due to the ongoing COVID pandemic, it will be virtual this year. To foster the local visualization community, we are hosting an in-person event during the conference.
 
-We will be live-streaming the shared events on **October 26 and 29** from [Gates Hillman Centers](https://map.concept3d.com/?id=192#!m/15778?ct/51581,7382), GHC 4405. We will also provide space for people to meet and get to know other visualization researchers or enthusiasts.
+We will be live-streaming the opening and closing sessions on October 26 and 29 from [Gates Hillman Centers](https://map.concept3d.com/?id=192#!m/15778?ct/51581,7382), GHC 4405. We will also provide space for people to meet and get to know other visualization researchers or enthusiasts.
 
-We will announce a detailed schedule here before the event.
+<!--more-->
 
-We organize the event following CMU's COVID regulations. We expect everyone to be vaccinated to attend the event. We may adjust the schedule or cancel if the situation changes dramatically.
+## Schedule
+
+On Tuesday October 26 8:30am—3pm we will show the VIS opening, awards, best paper presentations, keynote, and have time to meet.
+On Friday, October 29 12pm—3pm we will show the VIS capstone, closing, and have time to meet.
+
+## Attending
 
 If you want to attend or sponsor the VIS Satellite, we will provide contact information here shortly.
+
+## Details
+
+We organize the event following CMU's COVID regulations. We expect everyone to be vaccinated to attend the event. We may adjust the schedule or cancel if the situation changes dramatically.
 
 The organizers of the event are Adam Perer (CMU), Yu-Ru Lin (University of Pittsburgh), and Dominik Moritz (CMU).

--- a/_posts/2021-08-19-vis-satellite.md
+++ b/_posts/2021-08-19-vis-satellite.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: "VIS 2021 Satellite in Pittsburgh"
+date: 2021-08-19 12:00:00 -0400
+---
+
+We are hosting an [IEEE VIS 2021 Satellite Event](http://ieeevis.org/year/2021/info/satellite) at Carnegie Mellon University. VIS is the premier visualization conference. It usually happens every year in a different city around the world, but due to the ongoing COVID pandemic, it will be virtual this year. To foster the local visualization community, we are hosting an in-person event during the conference.
+
+We will be live-streaming the shared events on **October 26 and 29** from [Gates Hillman Centers](https://map.concept3d.com/?id=192#!m/15778?ct/51581,7382), GHC 4405. We will also provide space for people to meet and get to know other visualization researchers or enthusiasts.
+
+We will announce a detailed schedule here before the event.
+
+We organize the event following CMU's COVID regulations. We expect everyone to be vaccinated to attend the event. We may adjust the schedule or cancel if the situation changes dramatically.
+
+If you want to attend or sponsor the VIS Satellite, we will provide contact information here shortly.
+
+The organizers of the event are Adam Perer, Yu-Ru Lin, and Dominik Moritz.


### PR DESCRIPTION
Once this is merged, we can request a link from http://ieeevis.org/year/2021/info/satellite. 

Fixes #109 