### PR TITLE
pub comma to pipe

### DIFF
--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -36,7 +36,7 @@ layout: default
         {% endif %}
         {{ page.venue }}
         {% if page.venue_location %}
-          in {{ page.venue_location }}
+          | {{ page.venue_location }}
         {% endif %}
         {% if page.venue_url %}</a>{% endif %}
         {{ page.year }}

--- a/publications.html
+++ b/publications.html
@@ -70,7 +70,7 @@ description: Recent publications from the Data Interaction Group at Visualizatio
           {% endif %}
           {{ pub.venue }}
           {% if pub.venue_location %}
-          in {{ pub.venue_location }}
+            | {{ pub.venue_location }}
           {% endif %}
           {% if pub.venue_url %}</a>{% endif %}
         {{ pub.year }}


### PR DESCRIPTION
changed comma before venue and location so "in Virtual" doesn't sound as odd.

<img width="979" alt="Screen Shot 2022-06-16 at 08 22 31" src="https://user-images.githubusercontent.com/4563691/174068708-96358028-7383-4fc0-86d1-0308e43a8009.png">
