### PR TITLE
Add labmeeting invite footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -108,7 +108,8 @@
               <a href="https://twitter.com/cmudig" class="link white dim">@cmudig</a>.
             </div>
             <div class="pv1">
-              Our lab is in NSH A408.
+              Lab meetings Mon 1-2 PM @ NSH A408. If interested, please 
+      <a class="link white dim underline" href="mailto:dmoritz2@andrew.cmu.edu,aperer1@andrew.cmu.edu">Email Us</a>!
             </div>
             <div class="pt4">
               <abbr

--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@ layout: default
       mission is to empower everyone to analyze and communicate data with
       interactive systems.
     </p>
+    <p class="f4 measure lh-copy" style="pointer-events: auto;">Join us for our lab meetings held on Mondays from 1-2 PM in NSH. If you are interested in attending, please 
+      <a href="mailto:dmoritz2@andrew.cmu.edu,aperer1@andrew.cmu.edu">Email Us</a>!</p>
     <h3 style="pointer-events: auto">
       <a class="cta" href="{{ '/about' | relative_url }}"
         >Learn more about our group</a

--- a/index.html
+++ b/index.html
@@ -15,8 +15,6 @@ layout: default
       mission is to empower everyone to analyze and communicate data with
       interactive systems.
     </p>
-    <p class="f4 measure lh-copy" style="pointer-events: auto;">Join us for our lab meetings held on Mondays from 1-2 PM in NSH. If you are interested in attending, please 
-      <a href="mailto:dmoritz2@andrew.cmu.edu,aperer1@andrew.cmu.edu">Email Us</a>!</p>
     <h3 style="pointer-events: auto">
       <a class="cta" href="{{ '/about' | relative_url }}"
         >Learn more about our group</a


### PR DESCRIPTION
I was not sure where we wanted the message, so I have created two pull requests.

This pull request, the message is displayed in the footer, where previously there was the text: "Our lab is in NSH A408."

![image](https://github.com/user-attachments/assets/c206cc1e-88de-4f85-a556-e20b32ebc919)
