### PR TITLE
remove form for applying from website

### DIFF
--- a/team.html
+++ b/team.html
@@ -1,7 +1,9 @@
 ---
 layout: page
 title: Team
-subtitle: People define this group. If you are a current student at CMU, you can apply to the lab via <a href="https://forms.gle/6tHMesK3Yv8tkYtv5">this form</a>. If you are interested in a PhD with us, <a href="https://dig.cmu.edu/2020/10/03/join-us.html">please apply to CMU</a>.
+subtitle: People define this group.
+<!-- If you are a current student at CMU, you can apply to the lab via <a href="https://forms.gle/6tHMesK3Yv8tkYtv5">this form</a>. -->
+If you are interested in a PhD with us, <a href="https://dig.cmu.edu/2020/10/03/join-us.html">please apply to CMU</a>.
 roles:
   - Professor
   - PhD Student


### PR DESCRIPTION
I don't think we are consistently looking at this anymore and CMU has good mechanisms for advertising projects so I say we remove this until we have a better mechanism for reviewing candidates. 